### PR TITLE
Centralise authentication state in Context API (UserProvider)

### DIFF
--- a/src/components/sign-in-form/sign-in-form.component.jsx
+++ b/src/components/sign-in-form/sign-in-form.component.jsx
@@ -43,8 +43,7 @@ const SignInForm = () => {
   };
 
   const signInWithGoogle = async () => {
-    const { user } = await signInWithGooglePopup();
-    await createUserDocumentFromAuth(user);
+    await signInWithGooglePopup();
   };
 
   return (

--- a/src/components/sign-up-form/sign-up-form.component.jsx
+++ b/src/components/sign-up-form/sign-up-form.component.jsx
@@ -38,7 +38,6 @@ const SignUpForm = () => {
         email,
         password
       );
-
       resetFormFields();
 
       await createUserDocumentFromAuth(user, { displayName });

--- a/src/contexts/user.context.jsx
+++ b/src/contexts/user.context.jsx
@@ -1,0 +1,29 @@
+import { createContext, useState, useEffect } from 'react';
+
+import {
+  onAuthStateChangedListener,
+  createUserDocumentFromAuth,
+} from '../utils/firebase/firebase.utils';
+
+export const UserContext = createContext({
+  currentUser: null,
+  setCurrentUser: () => null,
+});
+
+export const UserProvider = ({ children }) => {
+  const [currentUser, setCurrentUser] = useState(null);
+  const value = { currentUser, setCurrentUser };
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChangedListener((user) => {
+      if (user) {
+        createUserDocumentFromAuth(user);
+      }
+      setCurrentUser(user);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router';
-import './index.scss';
+
 import App from './App';
-import reportWebVitals from './reportWebVitals';
+import { UserProvider } from './contexts/user.context';
+
+import './index.scss';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <UserProvider>
+        <App />
+      </UserProvider>
     </BrowserRouter>
   </React.StrictMode>
 );
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();

--- a/src/routes/navigation/navigation.component.jsx
+++ b/src/routes/navigation/navigation.component.jsx
@@ -1,11 +1,15 @@
-import { Fragment } from 'react/jsx-runtime';
+import { Fragment, useContext } from 'react';
 import { Outlet, Link } from 'react-router';
 
 import { ReactComponent as ShopLogo } from '../../assets/crown.svg';
+import { UserContext } from '../../contexts/user.context';
 
+import { signOutUser } from '../../utils/firebase/firebase.utils';
 import './navigation.styles.scss';
 
 const Navigation = () => {
+  const { currentUser } = useContext(UserContext);
+
   return (
     <Fragment>
       <div className='navigation'>
@@ -16,9 +20,15 @@ const Navigation = () => {
           <Link className='nav-link' to='/shop'>
             SHOP
           </Link>
-          <Link className='nav-link' to='/auth'>
-            SIGN IN
-          </Link>
+          {currentUser ? (
+            <span className='nav-link' onClick={signOutUser}>
+              SIGN OUT
+            </span>
+          ) : (
+            <Link className='nav-link' to='/auth'>
+              SIGN IN
+            </Link>
+          )}
         </Link>
       </div>
       <Outlet />

--- a/src/utils/firebase/firebase.utils.js
+++ b/src/utils/firebase/firebase.utils.js
@@ -5,6 +5,8 @@ import {
   GoogleAuthProvider,
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
+  signOut,
+  onAuthStateChanged,
 } from 'firebase/auth';
 import { getFirestore, doc, getDoc, setDoc } from 'firebase/firestore';
 
@@ -71,3 +73,8 @@ export const signInUserWithEmailAndPassword = async (email, password) => {
 
   return await signInWithEmailAndPassword(auth, email, password);
 };
+
+export const signOutUser = async () => await signOut(auth);
+
+export const onAuthStateChangedListener = (callback) =>
+  onAuthStateChanged(auth, callback);


### PR DESCRIPTION
- Added UserContext and UserProvider with onAuthStateChangedListener.
- Wrapped App with UserProvider.
- Navigation now uses currentUser and signOutUser.
- Removed local auth state from SignIn ( SignUp still passes displayName).
- Minor import and routing clean-ups.